### PR TITLE
fix: 🐛 dynamic container names breaking pkc binary

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,7 @@
 version: '3'
 services:
   database:
+    container_name: micro-pkc-database
     image: xlp0/mariadb
     restart: always
     networks:
@@ -20,7 +21,9 @@ services:
       - ./provision/mariadb:/docker-entrypoint-initdb.d
       - ./mountPoint/backup:/backup
       - ./mountPoint/MediaWiki_Backup:/MediaWiki_Backup
+
   mediawiki:
+    container_name: micro-pkc-mediawiki
     image: fantasticofox/pkc:latest
     restart: always
     networks:
@@ -45,7 +48,9 @@ services:
     depends_on:
       - database
       - eauth
+
   eauth:
+    container_name: micro-pkc-eauth
     image: pelith/node-eauth-server:latest
     restart: always
     networks:

--- a/pkc
+++ b/pkc
@@ -271,7 +271,7 @@ run_setup() {
 
     echo "Installing MediaWiki"
     # TODO split failure cases and remove || true
-    sudo docker exec micro-pkc_mediawiki_1 ./aqua/install_pkc.sh \
+    sudo docker exec micro-pkc-mediawiki ./aqua/install_pkc.sh \
                         --wallet-address "$WALLET_ADDRESS" \
                         --pkc-server "$PKC_SERVER" \
                         --eauth-server "$EAUTH_SERVER" \
@@ -279,7 +279,7 @@ run_setup() {
                         ${private:+--private} || true
 
     # TODO REMOVE THIS ONCE PELITH HAS FIXED THEIR RETRY BUG
-    sudo docker exec micro-pkc_eauth_1 pkill node
+    sudo docker exec micro-pkc-eauth pkill node
 
     echo "Done!"
 }
@@ -315,7 +315,7 @@ while [[ $# -gt 0 ]]; do
             break
             ;;
         backup)
-            sudo docker exec micro-pkc_mediawiki_1 /MediaWiki_Backup/backup.sh -d /backup -w /var/www/html -s -f
+            sudo docker exec micro-pkc-mediawiki /MediaWiki_Backup/backup.sh -d /backup -w /var/www/html -s -f
             break
             ;;
         restore)

--- a/scripts/create_and_promote_user.sh
+++ b/scripts/create_and_promote_user.sh
@@ -63,4 +63,4 @@ USERNAME=$(echo "$USERNAME" | tr "\[A-Z\]" "\[a-z\]")
 
 echo "INFO: The username is converted to lowercase to $USERNAME"
 
-sudo docker exec micro-pkc_mediawiki_1 php maintenance/createAndPromote.php $SYSOP "$USERNAME" "$PASSWORD"
+sudo docker exec micro-pkc-mediawiki php maintenance/createAndPromote.php $SYSOP "$USERNAME" "$PASSWORD"


### PR DESCRIPTION
container names hardcoded in a few spots based off a dynamic value
which changed with compose V2 when project nuked and containers
recreated

BREAKING CHANGE: 🧨 containers need to be recreated w/new labels

✅ Closes: #68