### PR TITLE
ci: 🎡 update docker manifest images for ownership

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ version: '3'
 services:
   database:
     container_name: micro-pkc-database
-    image: xlp0/mariadb
+    image: 0xc000007b/micro-pkc-mariadb
     restart: always
     networks:
       - common
@@ -24,7 +24,7 @@ services:
 
   mediawiki:
     container_name: micro-pkc-mediawiki
-    image: fantasticofox/pkc:latest
+    image: 0xc000007b/micro-pkc-mediawiki:37-1
     restart: always
     networks:
       - common
@@ -51,7 +51,7 @@ services:
 
   eauth:
     container_name: micro-pkc-eauth
-    image: pelith/node-eauth-server:latest
+    image: 0xc000007b/micro-pkc-eauth
     restart: always
     networks:
       - common
@@ -69,6 +69,7 @@ services:
       - VIRTUAL_PORT=${EAUTH_PORT}
     depends_on:
       - database
+
 networks:
   # We specify the internal network as common, so that the services in this
   # docker-compose.yml can be configured to interact with the services in the

--- a/pkc
+++ b/pkc
@@ -269,7 +269,8 @@ run_setup() {
     perl -i -p -e "s|PKC_SERVER|$PKC_SERVER|" .env
 
     echo "Executing docker compose up -d. Be prepared to type your password."
-    sudo docker compose up -d
+    # Support version 1 / 2 of docker-compose
+    sudo docker compose up -d 2>/dev/null || docker-compose up -d
     # Sleep; just to be sure that the container has initialized well.
     echo "Sleeping for 10 seconds to wait for the database to be ready."
     echo "Here's an invitation to grab a ☕ or take a deep breath."


### PR DESCRIPTION
closes #76

<img width="1319" alt="Screen Shot 2021-11-24 at 5 43 13 PM" src="https://user-images.githubusercontent.com/94251352/143213996-9636b5ae-ad8e-47dd-aaed-0e128d693f32.png">

Also cleans up some issues with the `pkc` script which were causing some issues on Linux for improved resilience. The case we found was when `docker compose` is available for the current user but not as `sudo`. I'll loop back in a separate pull to re-establish a check for Docker Compose installation.