### PR TITLE
Allow multiple backups per day

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ version: '3'
 services:
   database:
     container_name: micro-pkc-database
-    image: 0xc000007b/micro-pkc-mariadb
+    image: mariadb:10.6.4
     restart: always
     networks:
       - common

--- a/pkc
+++ b/pkc
@@ -339,7 +339,8 @@ while [[ $# -gt 0 ]]; do
             break
             ;;
         backup)
-            sudo docker exec micro-pkc-mediawiki /MediaWiki_Backup/backup.sh -d /backup -w /var/www/html -s -f
+            sudo docker exec micro-pkc-mediawiki /MediaWiki_Backup/backup.sh \
+                    -p "$(date -u +"%Y-%m-%dT%H-%M-%S_UTC")" -d /backup -w /var/www/html -s -f
             break
             ;;
         restore)


### PR DESCRIPTION
Allows us to run multiple backups per day in service of https://github.com/inblockio/micro-PKC/issues/88. Includes back-up related refactoring which removes an abstraction layer in Docker for a container which was running a cronjob every minute for an executable which doesn't exist in the container.

Once deployed and acceptance tested by business we may delete our fork of https://github.com/xlp0/DockerizedMariaDB